### PR TITLE
Change to get kubeconfig from commandlin or env

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -121,8 +121,10 @@ func NewDefaultObjectStorageController(identity string, leaderLockName string, t
 
 func NewObjectStorageController(identity string, leaderLockName string, threads int, limiter workqueue.RateLimiter) (*ObjectStorageController, error) {
 	cfg, err := func() (*rest.Config, error) {
-		kubeConfig := viper.GetString("kube-config")
-
+		kubeConfig := viper.GetString("kubeconfig")
+		if kubeConfig == "" {
+			kubeConfig = os.Getenv("KUBECONFIG")
+		}
 		if kubeConfig != "" {
 			return clientcmd.BuildConfigFromFlags("", kubeConfig)
 		}


### PR DESCRIPTION
It is required to honor KUBECONFIG env variable when running with local-up-cluster, etc. Also for consistency we use kubeconfig instead of kibe-config for command line argument.


/assign @wlan0 