### PR TITLE
crds: add `kustomization.yaml`

### DIFF
--- a/crds/kustomization.yaml
+++ b/crds/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - objectstorage.k8s.io_bucketaccesses.yaml
+  - objectstorage.k8s.io_bucketaccessclasses.yaml
+  - objectstorage.k8s.io_bucketaccessrequests.yaml
+  - objectstorage.k8s.io_bucketclasses.yaml
+  - objectstorage.k8s.io_bucketrequests.yaml
+  - objectstorage.k8s.io_buckets.yaml

--- a/crds/kustomization.yaml
+++ b/crds/kustomization.yaml
@@ -9,3 +9,13 @@ resources:
   - objectstorage.k8s.io_bucketclasses.yaml
   - objectstorage.k8s.io_bucketrequests.yaml
   - objectstorage.k8s.io_buckets.yaml
+
+patches:
+- target:
+    kind: CustomResourceDefinition
+  patch: |-
+    - op: add
+      path: /metadata/annotations
+      value:
+        controller-gen.kubebuilder.io/version: (devel)
+        api-approved.kubernetes.io: https://github.com/kubernetes-sigs/container-object-storage-interface-api/pull/2


### PR DESCRIPTION
This `kustomization` simply lists all CRD manifests. As such it can be referred to from other layers to import/include all CRDs in another rendering.

If this gets merged, we can refer to it as a *base* in `container-object-storage-interface-controller`s [deploy/base/kustomization.yaml](https://github.com/kubernetes-sigs/container-object-storage-interface-controller/blob/master/deploy/base/kustomization.yaml) instead of explicitly listing all CRD files (and keeping them in sync) as `resources`.