### PR TITLE
Removing the processing of Sync events

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/time/rate"
 
 	// objectstorage
-	v1alpha1 "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1"
+	"sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1"
 	bucketclientset "sigs.k8s.io/container-object-storage-interface-api/clientset"
 
 	// k8s api
@@ -371,7 +371,7 @@ func (c *ObjectStorageController) runController(ctx context.Context) {
 			Process: func(obj interface{}) error {
 				for _, d := range obj.(cache.Deltas) {
 					switch d.Type {
-					case cache.Sync, cache.Replaced, cache.Added, cache.Updated:
+					case cache.Replaced, cache.Added, cache.Updated:
 						if old, exists, err := indexer.Get(d.Object); err == nil && exists {
 							key, err := cache.MetaNamespaceKeyFunc(d.Object)
 							if err != nil {


### PR DESCRIPTION
The controller treats the Sync events in the same fashion as cache.Replaced, cache.Added, cache.Updated events.
Since resync happens every 30 * time.Second this results in continuously processing the BucketRequests 