### PR TITLE
adds conversion methods between spec and API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .build
 *.swp
 release-tools
+vendor
+.idea

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ This repository hosts the API defintion of the Custom Resource Definitions (CRD)
 
 **NOTE**: All of the APIs are defined under the API group `objectstorage.k8s.io`.
 
-For more information about COSI, visit our [documentation](https://github.com/kubernetes-sigs/container-object-storage-interface-api/tree/master/docs/index.md).
+For more information about COSI, visit our [documentation](https://sigs.k8s.io/container-object-storage-interface-api/tree/master/docs/index.md).
 
 ## Developer Guide
 
 All API definitions are in [`apis/objectstorage.k8s.io/`](./apis/objectstorage.k8s.io/). All API changes **_MUST_** satisfy the following requirements:
 
  - Must be backwards compatible
- - Must be in-sync with the API definitions in [sigs.k8s.io/container-object-storage-interface-spec](https://github.com/kubernetes-sigs/container-object-storage-interface-spec)
+ - Must be in-sync with the API definitions in [sigs.k8s.io/container-object-storage-interface-spec](https://sigs.k8s.io/container-object-storage-interface-spec)
 
 ### Build and Test
 

--- a/apis/objectstorage.k8s.io/v1alpha1/azure_types.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/azure_types.go
@@ -18,7 +18,25 @@ limitations under the License.
 
 package v1alpha1
 
+import osspec "sigs.k8s.io/container-object-storage-interface-spec"
+
 type AzureProtocol struct {
 	ContainerName  string `json:"containerName,omitempty"`
 	StorageAccount string `json:"storageAccount,omitempty"`
+}
+
+func (azure *AzureProtocol) ConvertToExternal() *osspec.Protocol_AzureBlob {
+	return &osspec.Protocol_AzureBlob{
+		AzureBlob: &osspec.AzureBlobParameters{
+			ContainerName:  azure.ContainerName,
+			StorageAccount: azure.StorageAccount,
+		},
+	}
+}
+
+func ConvertFromAzureExternal(ext *osspec.AzureBlobParameters) *AzureProtocol {
+	return &AzureProtocol{
+		StorageAccount: ext.StorageAccount,
+		ContainerName: ext.ContainerName,
+	}
 }

--- a/apis/objectstorage.k8s.io/v1alpha1/gcs_types.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/gcs_types.go
@@ -18,9 +18,31 @@ limitations under the License.
 
 package v1alpha1
 
+import osspec "sigs.k8s.io/container-object-storage-interface-spec"
+
 type GCSProtocol struct {
 	BucketName     string `json:"bucketName,omitempty"`
 	PrivateKeyName string `json:"privateKeyName,omitempty"`
 	ProjectID      string `json:"projectID,omitempty"`
 	ServiceAccount string `json:"serviceAccount,omitempty"`
+}
+
+func (gcs *GCSProtocol) ConvertToExternal() *osspec.Protocol_Gcs {
+	return &osspec.Protocol_Gcs{
+		Gcs: &osspec.GCSParameters{
+			BucketName:     gcs.BucketName,
+			PrivateKeyName: gcs.PrivateKeyName,
+			ProjectId:      gcs.ProjectID,
+			ServiceAccount: gcs.ServiceAccount,
+		},
+	}
+}
+
+func ConvertFromGCSExternal(ext *osspec.GCSParameters) *GCSProtocol {
+	return &GCSProtocol{
+		BucketName:     ext.BucketName,
+		PrivateKeyName: ext.PrivateKeyName,
+		ProjectID:      ext.ProjectId,
+		ServiceAccount: ext.ServiceAccount,
+	}
 }

--- a/apis/objectstorage.k8s.io/v1alpha1/openapi_generated.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/openapi_generated.go
@@ -156,7 +156,7 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			},
 		},
 		Dependencies: []string{
-			"sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketSpec", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketSpec", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketStatus"},
 	}
 }
 
@@ -199,7 +199,7 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			},
 		},
 		Dependencies: []string{
-			"sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessSpec", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessSpec", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessStatus"},
 	}
 }
 
@@ -303,7 +303,7 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			},
 		},
 		Dependencies: []string{
-			"sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessClass", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessClass"},
 	}
 }
 
@@ -349,7 +349,7 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			},
 		},
 		Dependencies: []string{
-			"sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccess", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccess"},
 	}
 }
 
@@ -392,7 +392,7 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			},
 		},
 		Dependencies: []string{
-			"sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessRequestSpec", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessRequestStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessRequestSpec", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessRequestStatus"},
 	}
 }
 
@@ -438,7 +438,7 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			},
 		},
 		Dependencies: []string{
-			"sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessRequest", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessRequest"},
 	}
 }
 
@@ -685,7 +685,7 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			},
 		},
 		Dependencies: []string{
-			"sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.AnonymousAccessMode", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.Protocol", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.AnonymousAccessMode", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.Protocol"},
 	}
 }
 
@@ -731,7 +731,7 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			},
 		},
 		Dependencies: []string{
-			"sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketClass", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketClass"},
 	}
 }
 
@@ -777,7 +777,7 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			},
 		},
 		Dependencies: []string{
-			"sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.Bucket", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.Bucket"},
 	}
 }
 
@@ -820,7 +820,7 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			},
 		},
 		Dependencies: []string{
-			"sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketRequestSpec", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketRequestStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketRequestSpec", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketRequestStatus"},
 	}
 }
 
@@ -866,7 +866,7 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			},
 		},
 		Dependencies: []string{
-			"sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketRequest", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketRequest"},
 	}
 }
 
@@ -1000,7 +1000,7 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			},
 		},
 		Dependencies: []string{
-			"sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.AnonymousAccessMode", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.Protocol", "k8s.io/api/core/v1.ObjectReference"},
+			"k8s.io/api/core/v1.ObjectReference", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.AnonymousAccessMode", "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.Protocol"},
 	}
 }
 

--- a/clientset/fake/register.go
+++ b/clientset/fake/register.go
@@ -29,7 +29,7 @@ import (
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
-
+var parameterCodec = runtime.NewParameterCodec(scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
 	objectstoragev1alpha1.AddToScheme,
 }

--- a/crds/objectstorage.k8s.io_bucketaccessclasses.yaml
+++ b/crds/objectstorage.k8s.io_bucketaccessclasses.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: bucketaccessclasses.objectstorage.k8s.io
 spec:

--- a/crds/objectstorage.k8s.io_bucketaccesses.yaml
+++ b/crds/objectstorage.k8s.io_bucketaccesses.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: bucketaccesses.objectstorage.k8s.io
 spec:

--- a/crds/objectstorage.k8s.io_bucketaccessrequests.yaml
+++ b/crds/objectstorage.k8s.io_bucketaccessrequests.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: bucketaccessrequests.objectstorage.k8s.io
 spec:

--- a/crds/objectstorage.k8s.io_bucketclasses.yaml
+++ b/crds/objectstorage.k8s.io_bucketclasses.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: bucketclasses.objectstorage.k8s.io
 spec:
@@ -91,8 +91,8 @@ spec:
                     type: string
                   signatureVersion:
                     enum:
-                    - s3v2
-                    - s3v4
+                    - S3V2
+                    - S3V4
                     type: string
                 type: object
               version:

--- a/crds/objectstorage.k8s.io_bucketrequests.yaml
+++ b/crds/objectstorage.k8s.io_bucketrequests.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: bucketrequests.objectstorage.k8s.io
 spec:

--- a/crds/objectstorage.k8s.io_buckets.yaml
+++ b/crds/objectstorage.k8s.io_buckets.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: buckets.objectstorage.k8s.io
 spec:
@@ -151,8 +151,8 @@ spec:
                         type: string
                       signatureVersion:
                         enum:
-                        - s3v2
-                        - s3v4
+                        - S3V2
+                        - S3V4
                         type: string
                     type: object
                   version:

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -20,16 +20,16 @@ Execute following commands to setup COSI:
 
 ```sh
 # Install CRDs
-kubectl create -k github.com/kubernetes-sigs/container-object-storage-interface-api
+kubectl create -k sigs.k8s.io/container-object-storage-interface-api
 
 # Install controller
-kubectl create -k github.com/kubernetes-sigs/container-object-storage-interface-controller
+kubectl create -k sigs.k8s.io/container-object-storage-interface-controller
 
 # Sample Provisioner and Sidecar
-kubectl create -k github.com/kubernetes-sigs/container-object-storage-interface-provisioner-sidecar
+kubectl create -k sigs.k8s.io/container-object-storage-interface-provisioner-sidecar
 
 # Node Adapter
-kubectl create -k github.com/kubernetes-sigs/container-object-storage-interface-csi-adapter
+kubectl create -k sigs.k8s.io/container-object-storage-interface-csi-adapter
 ```
 
 ### CustomResourceDefinitions
@@ -46,30 +46,30 @@ COSI acts on following custom resource definitions (CRDs):
 All [COSI custom resource definitions](../crds) can be installed using [kustomization file](../kustomization.yaml) and `kubectl` with following command:
 
 ```sh
-kubectl create -k github.com/kubernetes-sigs/container-object-storage-interface-api
+kubectl create -k sigs.k8s.io/container-object-storage-interface-api
 ```
 
 ### Controller
 
-COSI controller can be setup using the [kustomization file](https://github.com/kubernetes-sigs/container-object-storage-interface-controller/blob/master/kustomization.yaml) from the [container-object-storage-interface-controller](https://github.com/kubernetes-sigs/container-object-storage-interface-controller) repository with following command:
+COSI controller can be setup using the [kustomization file](https://sigs.k8s.io/container-object-storage-interface-controller/blob/master/kustomization.yaml) from the [container-object-storage-interface-controller](https://sigs.k8s.io/container-object-storage-interface-controller) repository with following command:
 
 ```sh
-kubectl create -k github.com/kubernetes-sigs/container-object-storage-interface-controller
+kubectl create -k sigs.k8s.io/container-object-storage-interface-controller
 ```
 
 The controller will be deployed in the `default` namespace.
 
 ### Sample Driver & Sidecar
 
-Sample Driver & Sidecar can be setup using the [kustomization file](https://github.com/kubernetes-sigs/container-object-storage-interface-provisioner-sidecar/blob/master/kustomization.yaml) from the [container-object-storage-interface-provisioner-sidecar](https://github.com/kubernetes-sigs/container-object-storage-interface-provisioner-sidecar) repository with following command:
+Sample Driver & Sidecar can be setup using the [kustomization file](https://sigs.k8s.io/container-object-storage-interface-provisioner-sidecar/blob/master/kustomization.yaml) from the [container-object-storage-interface-provisioner-sidecar](https://sigs.k8s.io/container-object-storage-interface-provisioner-sidecar) repository with following command:
 
 ```sh
-kubectl create -k github.com/kubernetes-sigs/container-object-storage-interface-provisioner-sidecar
+kubectl create -k sigs.k8s.io/container-object-storage-interface-provisioner-sidecar
 ```
 ### Node Adapter
 
-Node adapter can be setup using the [kustomization file](https://github.com/kubernetes-sigs/container-object-storage-interface-csi-adapter/blob/master/kustomization.yaml) from the [container-object-storage-interface-csi-adapter](https://github.com/kubernetes-sigs/container-object-storage-interface-csi-adapter) repository with following command:
+Node adapter can be setup using the [kustomization file](https://sigs.k8s.io/container-object-storage-interface-csi-adapter/blob/master/kustomization.yaml) from the [container-object-storage-interface-csi-adapter](https://sigs.k8s.io/container-object-storage-interface-csi-adapter) repository with following command:
 
 ```sh
-kubectl create -k github.com/kubernetes-sigs/container-object-storage-interface-csi-adapter
+kubectl create -k sigs.k8s.io/container-object-storage-interface-csi-adapter
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,5 +36,5 @@ The existing primitives in CSI do not apply to objectstorage. Thus the need for 
 ## Other
 
  - [Project Board](https://github.com/orgs/kubernetes-sigs/projects/8)
- - [Weekly Meetings](https://github.com/kubernetes-sigs/container-object-storage-interface-api/tree/master/docs/meetings.md)
+ - [Weekly Meetings](https://sigs.k8s.io/container-object-storage-interface-api/tree/master/docs/meetings.md)
  - [Roadmap](https://github.com/orgs/kubernetes-sigs/projects/8)

--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,6 @@ require (
 	k8s.io/apimachinery v0.19.4
 	k8s.io/client-go v0.19.4
 	k8s.io/kube-openapi v0.0.0-20200923155610-8b5066479488
+	sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210224211525-dfa3af562c18
 	sigs.k8s.io/controller-runtime v0.6.3
 )

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,7 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
@@ -62,6 +63,7 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/dave/jennifer v1.4.1/go.mod h1:7jEdnm+qBcxl8PC0zyp7vxcpSRnzXSt9r39tpTVGlwA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -77,7 +79,9 @@ github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkg
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -176,6 +180,8 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
+github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -183,6 +189,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
+github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -194,6 +202,7 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
@@ -333,6 +342,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
@@ -404,6 +414,7 @@ golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191002035440-2ec189313ef0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
@@ -514,14 +525,18 @@ google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
 google.golang.org/genproto v0.0.0-20191230161307-f3c370f40bfb/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
+google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.35.0 h1:TwIQcH3es+MojMVojxxfQ3l3OF2KzlRxML2xZq0kRo8=
+google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -532,6 +547,8 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0 h1:UhZDfRO8JRQru4/+LlLE0BRKGF8L+PICnvYZmx/fEGA=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
+google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
+google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -596,6 +613,8 @@ k8s.io/utils v0.0.0-20200729134348-d5654de09c73 h1:uJmqzgNWG7XyClnU/mLPBWwfKKF1K
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=
+sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210224211525-dfa3af562c18 h1:TIx7kV6/3ZSQ5BETBx1QG1Va28zv1LZAvqRjs28n8ss=
+sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210224211525-dfa3af562c18/go.mod h1:kafkL5l/lTUrZXhVi/9p1GzpEE/ts29BkWkL3Ao33WU=
 sigs.k8s.io/controller-runtime v0.6.3 h1:SBbr+inLPEKhvlJtrvDcwIpm+uhDvp63Bl72xYJtoOE=
 sigs.k8s.io/controller-runtime v0.6.3/go.mod h1:WlZNXcM0++oyaQt4B7C2lEE5JYRs8vJUzRP4N4JpdAY=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -2,38 +2,38 @@
 
 SCRIPT_ROOT=$(dirname $0)
 
-deepcopy-gen --input-dirs github.com/kubernetes-sigs/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1 \
+deepcopy-gen --input-dirs sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1 \
              --go-header-file hack/boilerplate.go.txt \
 	     --output-base $GOPATH/src \
 	     --output-file-base zz_generated.deepcopy \
-	     --output-package github.com/kubernetes-sigs/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1
+	     --output-package sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1
 
-openapi-gen --input-dirs github.com/kubernetes-sigs/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1 \
+openapi-gen --input-dirs sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1 \
             --go-header-file hack/boilerplate.go.txt \
 	    --output-base $GOPATH/src \
-	    --output-package github.com/kubernetes-sigs/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1
+	    --output-package sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1
 
-defaulter-gen --input-dirs github.com/kubernetes-sigs/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1 \
+defaulter-gen --input-dirs sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1 \
               --go-header-file hack/boilerplate.go.txt \
 	      --output-base $GOPATH/src \
-	      --output-package github.com/kubernetes-sigs/container-object-storage-interface-api/defaulters
+	      --output-package sigs.k8s.io/container-object-storage-interface-api/defaulters
 
-lister-gen --input-dirs github.com/kubernetes-sigs/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1 \
+lister-gen --input-dirs sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1 \
               --go-header-file hack/boilerplate.go.txt \
 	      --output-base $GOPATH/src \
-	      --output-package github.com/kubernetes-sigs/container-object-storage-interface-api/listers
+	      --output-package sigs.k8s.io/container-object-storage-interface-api/listers
 
-informer-gen --input-dirs github.com/kubernetes-sigs/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1 \
+informer-gen --input-dirs sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1 \
               --go-header-file hack/boilerplate.go.txt \
 	      --output-base $GOPATH/src \
-	      --listers-package github.com/kubernetes-sigs/container-object-storage-interface-api/listers \
-	      --versioned-clientset-package github.com/kubernetes-sigs/container-object-storage-interface-api/clientset \
-	      --output-package github.com/kubernetes-sigs/container-object-storage-interface-api/informers
+	      --listers-package sigs.k8s.io/container-object-storage-interface-api/listers \
+	      --versioned-clientset-package sigs.k8s.io/container-object-storage-interface-api/clientset \
+	      --output-package sigs.k8s.io/container-object-storage-interface-api/informers
 
 client-gen --input objectstorage.k8s.io/v1alpha1 \
            --go-header-file hack/boilerplate.go.txt \
-	   --input-base github.com/kubernetes-sigs/container-object-storage-interface-api/apis/ \
-	   --output-package github.com/kubernetes-sigs/container-object-storage-interface-api/ \
+	   --input-base sigs.k8s.io/container-object-storage-interface-api/apis/ \
+	   --output-package sigs.k8s.io/container-object-storage-interface-api/ \
 	   --output-base $GOPATH/src \
 	   --clientset-name "clientset"
 

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -7,7 +7,7 @@ commonAnnotations:
   cosi.storage.k8s.io/license: "Apache V2"
   cosi.storage.k8s.io/support: "https://github.com/kubernetes-sigs/container-object-storage-api"
   controller-gen.kubebuilder.io/version: (devel)
-  api-approved.kubernetes.io: https://github.com/kubernetes-sigs/container-object-storage-interface-api/pull/2
+  api-approved.kubernetes.io: https://sigs.k8s.io/container-object-storage-interface-api/pull/2
 
 
 resources:

--- a/listers/objectstorage.k8s.io/v1alpha1/bucket.go
+++ b/listers/objectstorage.k8s.io/v1alpha1/bucket.go
@@ -26,13 +26,10 @@ import (
 )
 
 // BucketLister helps list Buckets.
-// All objects returned here must be treated as read-only.
 type BucketLister interface {
 	// List lists all Buckets in the indexer.
-	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.Bucket, err error)
 	// Get retrieves the Bucket from the index for a given name.
-	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.Bucket, error)
 	BucketListerExpansion
 }

--- a/listers/objectstorage.k8s.io/v1alpha1/bucketaccess.go
+++ b/listers/objectstorage.k8s.io/v1alpha1/bucketaccess.go
@@ -26,13 +26,10 @@ import (
 )
 
 // BucketAccessLister helps list BucketAccesses.
-// All objects returned here must be treated as read-only.
 type BucketAccessLister interface {
 	// List lists all BucketAccesses in the indexer.
-	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.BucketAccess, err error)
 	// Get retrieves the BucketAccess from the index for a given name.
-	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.BucketAccess, error)
 	BucketAccessListerExpansion
 }

--- a/listers/objectstorage.k8s.io/v1alpha1/bucketaccessclass.go
+++ b/listers/objectstorage.k8s.io/v1alpha1/bucketaccessclass.go
@@ -26,13 +26,10 @@ import (
 )
 
 // BucketAccessClassLister helps list BucketAccessClasses.
-// All objects returned here must be treated as read-only.
 type BucketAccessClassLister interface {
 	// List lists all BucketAccessClasses in the indexer.
-	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.BucketAccessClass, err error)
 	// Get retrieves the BucketAccessClass from the index for a given name.
-	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.BucketAccessClass, error)
 	BucketAccessClassListerExpansion
 }

--- a/listers/objectstorage.k8s.io/v1alpha1/bucketaccessrequest.go
+++ b/listers/objectstorage.k8s.io/v1alpha1/bucketaccessrequest.go
@@ -26,10 +26,8 @@ import (
 )
 
 // BucketAccessRequestLister helps list BucketAccessRequests.
-// All objects returned here must be treated as read-only.
 type BucketAccessRequestLister interface {
 	// List lists all BucketAccessRequests in the indexer.
-	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.BucketAccessRequest, err error)
 	// BucketAccessRequests returns an object that can list and get BucketAccessRequests.
 	BucketAccessRequests(namespace string) BucketAccessRequestNamespaceLister
@@ -60,13 +58,10 @@ func (s *bucketAccessRequestLister) BucketAccessRequests(namespace string) Bucke
 }
 
 // BucketAccessRequestNamespaceLister helps list and get BucketAccessRequests.
-// All objects returned here must be treated as read-only.
 type BucketAccessRequestNamespaceLister interface {
 	// List lists all BucketAccessRequests in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.BucketAccessRequest, err error)
 	// Get retrieves the BucketAccessRequest from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.BucketAccessRequest, error)
 	BucketAccessRequestNamespaceListerExpansion
 }

--- a/listers/objectstorage.k8s.io/v1alpha1/bucketclass.go
+++ b/listers/objectstorage.k8s.io/v1alpha1/bucketclass.go
@@ -26,13 +26,10 @@ import (
 )
 
 // BucketClassLister helps list BucketClasses.
-// All objects returned here must be treated as read-only.
 type BucketClassLister interface {
 	// List lists all BucketClasses in the indexer.
-	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.BucketClass, err error)
 	// Get retrieves the BucketClass from the index for a given name.
-	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.BucketClass, error)
 	BucketClassListerExpansion
 }

--- a/listers/objectstorage.k8s.io/v1alpha1/bucketrequest.go
+++ b/listers/objectstorage.k8s.io/v1alpha1/bucketrequest.go
@@ -26,10 +26,8 @@ import (
 )
 
 // BucketRequestLister helps list BucketRequests.
-// All objects returned here must be treated as read-only.
 type BucketRequestLister interface {
 	// List lists all BucketRequests in the indexer.
-	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.BucketRequest, err error)
 	// BucketRequests returns an object that can list and get BucketRequests.
 	BucketRequests(namespace string) BucketRequestNamespaceLister
@@ -60,13 +58,10 @@ func (s *bucketRequestLister) BucketRequests(namespace string) BucketRequestName
 }
 
 // BucketRequestNamespaceLister helps list and get BucketRequests.
-// All objects returned here must be treated as read-only.
 type BucketRequestNamespaceLister interface {
 	// List lists all BucketRequests in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.BucketRequest, err error)
 	// Get retrieves the BucketRequest from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.BucketRequest, error)
 	BucketRequestNamespaceListerExpansion
 }


### PR DESCRIPTION
This PR adds some utility methods to convert resources between the Spec and the API, these methods can, in turn, be consumed by the sidecar, or vendor drivers. There are also some minor changes to the API to make this process smoother.