### PR TITLE
remove provisioner from bucketAccess

### DIFF
--- a/apis/objectstorage.k8s.io/v1alpha1/openapi_generated.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/openapi_generated.go
@@ -486,12 +486,6 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"provisioner": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 					"bucketInstanceName": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},

--- a/apis/objectstorage.k8s.io/v1alpha1/types.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/types.go
@@ -231,9 +231,6 @@ type BucketAccess struct {
 
 type BucketAccessSpec struct {
 	// +optional
-	Provisioner string `json:"provisioner,omitempty"`
-
-	// +optional
 	BucketInstanceName string `json:"bucketInstanceName,omitempty"`
 
 	// +optional

--- a/crds/objectstorage.k8s.io_bucketaccesses.yaml
+++ b/crds/objectstorage.k8s.io_bucketaccesses.yaml
@@ -105,8 +105,6 @@ spec:
                 type: string
               principal:
                 type: string
-              provisioner:
-                type: string
               serviceAccount:
                 description: 'ObjectReference contains enough information to let you
                   inspect or modify the referred object. --- New uses of this type


### PR DESCRIPTION
Since the source of truth for provisioner is the bucket itself, is there a need to have provisionerName inside the BucketAccess object? 