### PR TITLE
use bucketName instead of bucketName and bucketInstanceName

### DIFF
--- a/apis/objectstorage.k8s.io/v1alpha1/azure_types.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/azure_types.go
@@ -27,14 +27,14 @@ type AzureProtocol struct {
 
 func (azure *AzureProtocol) ConvertToExternal() *osspec.Protocol_AzureBlob {
 	return &osspec.Protocol_AzureBlob{
-		AzureBlob: &osspec.AzureBlobParameters{
+		AzureBlob: &osspec.AzureBlob{
 			ContainerName:  azure.ContainerName,
 			StorageAccount: azure.StorageAccount,
 		},
 	}
 }
 
-func ConvertFromAzureExternal(ext *osspec.AzureBlobParameters) *AzureProtocol {
+func ConvertFromAzureExternal(ext *osspec.AzureBlob) *AzureProtocol {
 	return &AzureProtocol{
 		StorageAccount: ext.StorageAccount,
 		ContainerName: ext.ContainerName,

--- a/apis/objectstorage.k8s.io/v1alpha1/gcs_types.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/gcs_types.go
@@ -29,7 +29,7 @@ type GCSProtocol struct {
 
 func (gcs *GCSProtocol) ConvertToExternal() *osspec.Protocol_Gcs {
 	return &osspec.Protocol_Gcs{
-		Gcs: &osspec.GCSParameters{
+		Gcs: &osspec.GCS{
 			BucketName:     gcs.BucketName,
 			PrivateKeyName: gcs.PrivateKeyName,
 			ProjectId:      gcs.ProjectID,
@@ -38,7 +38,7 @@ func (gcs *GCSProtocol) ConvertToExternal() *osspec.Protocol_Gcs {
 	}
 }
 
-func ConvertFromGCSExternal(ext *osspec.GCSParameters) *GCSProtocol {
+func ConvertFromGCSExternal(ext *osspec.GCS) *GCSProtocol {
 	return &GCSProtocol{
 		BucketName:     ext.BucketName,
 		PrivateKeyName: ext.PrivateKeyName,

--- a/apis/objectstorage.k8s.io/v1alpha1/openapi_generated.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/openapi_generated.go
@@ -430,9 +430,14 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"bucketRequestName": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"bucketName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"bucketAccessClassName": {
@@ -442,14 +447,8 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 							Format:  "",
 						},
 					},
-					"bucketAccessName": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 				},
-				Required: []string{"bucketRequestName", "bucketAccessClassName"},
+				Required: []string{"bucketAccessClassName"},
 			},
 		},
 	}
@@ -474,6 +473,12 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 							Format:  "",
 						},
 					},
+					"bucketAccessName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},
@@ -486,7 +491,7 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"bucketInstanceName": {
+					"bucketName": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",
@@ -856,12 +861,6 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"bucketInstanceName": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 					"bucketPrefix": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -897,6 +896,12 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 							Default: false,
 							Type:    []string{"boolean"},
 							Format:  "",
+						},
+					},
+					"bucketName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},

--- a/apis/objectstorage.k8s.io/v1alpha1/openapi_generated.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/openapi_generated.go
@@ -519,7 +519,7 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 							Format: "",
 						},
 					},
-					"principal": {
+					"accountID": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",

--- a/apis/objectstorage.k8s.io/v1alpha1/s3_types.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/s3_types.go
@@ -44,7 +44,7 @@ func (s3 *S3Protocol) ConvertToExternal() *osspec.Protocol_S3 {
 		sigver = 0
 	}
 	return &osspec.Protocol_S3{
-		S3: &osspec.S3Parameters{
+		S3: &osspec.S3{
 			Endpoint:         s3.Endpoint,
 			BucketName:       s3.BucketName,
 			Region:           s3.Region,
@@ -53,7 +53,7 @@ func (s3 *S3Protocol) ConvertToExternal() *osspec.Protocol_S3 {
 	}
 }
 
-func ConvertFromS3External(ext *osspec.S3Parameters) *S3Protocol {
+func ConvertFromS3External(ext *osspec.S3) *S3Protocol {
 	vers, ok := osspec.S3SignatureVersion_name[int32(ext.SignatureVersion)]
 	if !ok {
 		vers = osspec.S3SignatureVersion_name[0]

--- a/apis/objectstorage.k8s.io/v1alpha1/types.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/types.go
@@ -245,7 +245,7 @@ type BucketAccessSpec struct {
 	PolicyActionsConfigMapData string `json:"policyActionsConfigMapData,omitempty"`
 
 	// +optional
-	Principal string `json:"principal,omitempty"`
+	AccountID string `json:"accountID,omitempty"`
 
 	// +optional
 	Parameters map[string]string `json:"parameters,omitempty"`

--- a/apis/objectstorage.k8s.io/v1alpha1/types.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/types.go
@@ -118,9 +118,6 @@ type BucketRequest struct {
 
 type BucketRequestSpec struct {
 	// +optional
-	BucketInstanceName string `json:"bucketInstanceName,omitempty"`
-
-	// +optional
 	BucketPrefix string `json:"bucketPrefix,omitempty"`
 
 	// +optional
@@ -133,6 +130,9 @@ type BucketRequestStatus struct {
 
 	// +optional
 	BucketAvailable bool `json:"bucketAvailable"`
+
+	// +optional
+	BucketName string `json:"bucketName,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -231,7 +231,7 @@ type BucketAccess struct {
 
 type BucketAccessSpec struct {
 	// +optional
-	BucketInstanceName string `json:"bucketInstanceName,omitempty"`
+	BucketName string `json:"bucketName,omitempty"`
 
 	// +optional
 	BucketAccessRequest *corev1.ObjectReference `json:"bucketAccessRequest,omitempty"`
@@ -288,13 +288,12 @@ type BucketAccessRequest struct {
 type BucketAccessRequestSpec struct {
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
-
-	BucketRequestName string `json:"bucketRequestName"`
+	// +optional
+	BucketRequestName string `json:"bucketRequestName,omitempty"`
+	// +optional
+	BucketName string `json:"bucketName,omitempty"`
 
 	BucketAccessClassName string `json:"bucketAccessClassName"`
-
-	// +optional
-	BucketAccessName string `json:"bucketAccessName,omitempty"`
 }
 
 type BucketAccessRequestStatus struct {
@@ -303,6 +302,9 @@ type BucketAccessRequestStatus struct {
 
 	// +optional
 	AccessGranted bool `json:"accessGranted"`
+
+	// +optional
+	BucketAccessName string `json:"bucketAccessName,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -159,8 +159,8 @@ func NewObjectStorageControllerWithClientset(identity string, leaderLockName str
 		ResyncPeriod: 30 * time.Second,
 		// leader election
 		LeaseDuration: 60 * time.Second,
-		RenewDeadline: 15 * time.Second,
-		RetryPeriod:   5 * time.Second,
+		RenewDeadline: 30 * time.Second,
+		RetryPeriod:   15 * time.Second,
 
 		opMap: &sync.Map{},
 	}, nil

--- a/crds/objectstorage.k8s.io_bucketaccesses.yaml
+++ b/crds/objectstorage.k8s.io_bucketaccesses.yaml
@@ -34,6 +34,8 @@ spec:
             type: object
           spec:
             properties:
+              accountID:
+                type: string
               bucketAccessRequest:
                 description: 'ObjectReference contains enough information to let you
                   inspect or modify the referred object. --- New uses of this type
@@ -102,8 +104,6 @@ spec:
                   type: string
                 type: object
               policyActionsConfigMapData:
-                type: string
-              principal:
                 type: string
               serviceAccount:
                 description: 'ObjectReference contains enough information to let you

--- a/crds/objectstorage.k8s.io_bucketaccesses.yaml
+++ b/crds/objectstorage.k8s.io_bucketaccesses.yaml
@@ -93,7 +93,7 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
-              bucketInstanceName:
+              bucketName:
                 type: string
               mintedSecretName:
                 type: string

--- a/crds/objectstorage.k8s.io_bucketaccessrequests.yaml
+++ b/crds/objectstorage.k8s.io_bucketaccessrequests.yaml
@@ -36,7 +36,7 @@ spec:
             properties:
               bucketAccessClassName:
                 type: string
-              bucketAccessName:
+              bucketName:
                 type: string
               bucketRequestName:
                 type: string
@@ -44,12 +44,13 @@ spec:
                 type: string
             required:
             - bucketAccessClassName
-            - bucketRequestName
             type: object
           status:
             properties:
               accessGranted:
                 type: boolean
+              bucketAccessName:
+                type: string
               message:
                 type: string
             type: object

--- a/crds/objectstorage.k8s.io_bucketrequests.yaml
+++ b/crds/objectstorage.k8s.io_bucketrequests.yaml
@@ -36,8 +36,6 @@ spec:
             properties:
               bucketClassName:
                 type: string
-              bucketInstanceName:
-                type: string
               bucketPrefix:
                 type: string
             type: object
@@ -45,6 +43,8 @@ spec:
             properties:
               bucketAvailable:
                 type: boolean
+              bucketName:
+                type: string
               message:
                 type: string
             type: object

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,6 @@ require (
 	k8s.io/apimachinery v0.19.4
 	k8s.io/client-go v0.19.4
 	k8s.io/kube-openapi v0.0.0-20200923155610-8b5066479488
-	sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210224211525-dfa3af562c18
+	sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210329232956-3bbacbbc9c19
 	sigs.k8s.io/controller-runtime v0.6.3
 )

--- a/go.sum
+++ b/go.sum
@@ -617,6 +617,8 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=
 sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210224211525-dfa3af562c18 h1:TIx7kV6/3ZSQ5BETBx1QG1Va28zv1LZAvqRjs28n8ss=
 sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210224211525-dfa3af562c18/go.mod h1:kafkL5l/lTUrZXhVi/9p1GzpEE/ts29BkWkL3Ao33WU=
+sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210329232956-3bbacbbc9c19 h1:LrLrBCBqO7O/VjJtTrDSj3/f7hLSQaCIouLZFnHGxFg=
+sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210329232956-3bbacbbc9c19/go.mod h1:kafkL5l/lTUrZXhVi/9p1GzpEE/ts29BkWkL3Ao33WU=
 sigs.k8s.io/controller-runtime v0.6.3 h1:SBbr+inLPEKhvlJtrvDcwIpm+uhDvp63Bl72xYJtoOE=
 sigs.k8s.io/controller-runtime v0.6.3/go.mod h1:WlZNXcM0++oyaQt4B7C2lEE5JYRs8vJUzRP4N4JpdAY=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=


### PR DESCRIPTION
The previous design had the two values be different, now that the backend bucket name and the name of the bucket object are the same, it doesn't make sense to have two different field names for the same value. @bswartz
