### PR TITLE
Removes bucketName fields from Protocol

### DIFF
--- a/apis/objectstorage.k8s.io/v1alpha1/azure_types.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/azure_types.go
@@ -21,14 +21,12 @@ package v1alpha1
 import osspec "sigs.k8s.io/container-object-storage-interface-spec"
 
 type AzureProtocol struct {
-	ContainerName  string `json:"containerName,omitempty"`
 	StorageAccount string `json:"storageAccount,omitempty"`
 }
 
 func (azure *AzureProtocol) ConvertToExternal() *osspec.Protocol_AzureBlob {
 	return &osspec.Protocol_AzureBlob{
 		AzureBlob: &osspec.AzureBlob{
-			ContainerName:  azure.ContainerName,
 			StorageAccount: azure.StorageAccount,
 		},
 	}
@@ -37,6 +35,5 @@ func (azure *AzureProtocol) ConvertToExternal() *osspec.Protocol_AzureBlob {
 func ConvertFromAzureExternal(ext *osspec.AzureBlob) *AzureProtocol {
 	return &AzureProtocol{
 		StorageAccount: ext.StorageAccount,
-		ContainerName: ext.ContainerName,
 	}
 }

--- a/apis/objectstorage.k8s.io/v1alpha1/gcs_types.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/gcs_types.go
@@ -21,7 +21,6 @@ package v1alpha1
 import osspec "sigs.k8s.io/container-object-storage-interface-spec"
 
 type GCSProtocol struct {
-	BucketName     string `json:"bucketName,omitempty"`
 	PrivateKeyName string `json:"privateKeyName,omitempty"`
 	ProjectID      string `json:"projectID,omitempty"`
 	ServiceAccount string `json:"serviceAccount,omitempty"`
@@ -30,7 +29,6 @@ type GCSProtocol struct {
 func (gcs *GCSProtocol) ConvertToExternal() *osspec.Protocol_Gcs {
 	return &osspec.Protocol_Gcs{
 		Gcs: &osspec.GCS{
-			BucketName:     gcs.BucketName,
 			PrivateKeyName: gcs.PrivateKeyName,
 			ProjectId:      gcs.ProjectID,
 			ServiceAccount: gcs.ServiceAccount,
@@ -40,7 +38,6 @@ func (gcs *GCSProtocol) ConvertToExternal() *osspec.Protocol_Gcs {
 
 func ConvertFromGCSExternal(ext *osspec.GCS) *GCSProtocol {
 	return &GCSProtocol{
-		BucketName:     ext.BucketName,
 		PrivateKeyName: ext.PrivateKeyName,
 		ProjectID:      ext.ProjectId,
 		ServiceAccount: ext.ServiceAccount,

--- a/apis/objectstorage.k8s.io/v1alpha1/openapi_generated.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/openapi_generated.go
@@ -62,12 +62,6 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"containerName": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 					"storageAccount": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -102,17 +96,20 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketStatus"),
+							Default: map[string]interface{}{},
+							Ref:     ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketStatus"),
 						},
 					},
 				},
@@ -145,17 +142,20 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessStatus"),
+							Default: map[string]interface{}{},
+							Ref:     ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessStatus"),
 						},
 					},
 				},
@@ -188,7 +188,8 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"policyActionsConfigMap": {
@@ -203,8 +204,9 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -240,7 +242,8 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -249,7 +252,8 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessClass"),
+										Default: map[string]interface{}{},
+										Ref:     ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessClass"),
 									},
 								},
 							},
@@ -286,7 +290,8 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -295,7 +300,8 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccess"),
+										Default: map[string]interface{}{},
+										Ref:     ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccess"),
 									},
 								},
 							},
@@ -332,17 +338,20 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessRequestSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessRequestSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessRequestStatus"),
+							Default: map[string]interface{}{},
+							Ref:     ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessRequestStatus"),
 						},
 					},
 				},
@@ -375,7 +384,8 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -384,7 +394,8 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessRequest"),
+										Default: map[string]interface{}{},
+										Ref:     ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketAccessRequest"),
 									},
 								},
 							},
@@ -425,8 +436,9 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"bucketAccessClassName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 				},
@@ -450,8 +462,9 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"accessGranted": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Default: false,
+							Type:    []string{"boolean"},
+							Format:  "",
 						},
 					},
 					"bucketAccessName": {
@@ -501,8 +514,9 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -575,7 +589,8 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"provisioner": {
@@ -601,8 +616,9 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -610,7 +626,8 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"protocol": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.Protocol"),
+							Default: map[string]interface{}{},
+							Ref:     ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.Protocol"),
 						},
 					},
 					"deletionPolicy": {
@@ -626,8 +643,9 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -664,7 +682,8 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -673,7 +692,8 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketClass"),
+										Default: map[string]interface{}{},
+										Ref:     ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketClass"),
 									},
 								},
 							},
@@ -710,7 +730,8 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -719,7 +740,8 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.Bucket"),
+										Default: map[string]interface{}{},
+										Ref:     ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.Bucket"),
 									},
 								},
 							},
@@ -756,17 +778,20 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketRequestSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketRequestSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketRequestStatus"),
+							Default: map[string]interface{}{},
+							Ref:     ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketRequestStatus"),
 						},
 					},
 				},
@@ -799,7 +824,8 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -808,7 +834,8 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketRequest"),
+										Default: map[string]interface{}{},
+										Ref:     ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.BucketRequest"),
 									},
 								},
 							},
@@ -861,8 +888,9 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"bucketAvailable": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Default: false,
+							Type:    []string{"boolean"},
+							Format:  "",
 						},
 					},
 					"bucketName": {
@@ -911,8 +939,9 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -920,7 +949,8 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"protocol": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.Protocol"),
+							Default: map[string]interface{}{},
+							Ref:     ref("sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1.Protocol"),
 						},
 					},
 					"parameters": {
@@ -930,8 +960,9 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -939,8 +970,16 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"deletionPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"bucketID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "BucketID is used for brownfield creation of buckets",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -972,8 +1011,9 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 					},
 					"bucketID": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "BucketID is either filled in based on the brown name of the bucket, or it is dynamic filled based on the newly provisioned bucket",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -988,12 +1028,6 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"bucketName": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 					"privateKeyName": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -1053,18 +1087,6 @@ func schema_container_object_storage_interface_api_apis_objectstoragek8sio_v1alp
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"endpoint": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"bucketName": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 					"region": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},

--- a/apis/objectstorage.k8s.io/v1alpha1/protocol_types.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/protocol_types.go
@@ -25,10 +25,6 @@ import (
 type ProtocolName string
 
 const (
-	ProtocolNameS3    ProtocolName = "s3"
-	ProtocolNameAzure ProtocolName = "azureBlob"
-	ProtocolNameGCS   ProtocolName = "gcs"
-
 	InvalidProtocol = "invalid protocol"
 )
 

--- a/apis/objectstorage.k8s.io/v1alpha1/s3_types.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/s3_types.go
@@ -30,8 +30,6 @@ const (
 )
 
 type S3Protocol struct {
-	Endpoint   string `json:"endpoint,omitempty"`
-	BucketName string `json:"bucketName,omitempty"`
 	Region     string `json:"region,omitempty"`
 	// +kubebuilder:validation:Enum:={S3V2,S3V4}
 	SignatureVersion S3SignatureVersion `json:"signatureVersion,omitempty"`
@@ -45,8 +43,6 @@ func (s3 *S3Protocol) ConvertToExternal() *osspec.Protocol_S3 {
 	}
 	return &osspec.Protocol_S3{
 		S3: &osspec.S3{
-			Endpoint:         s3.Endpoint,
-			BucketName:       s3.BucketName,
 			Region:           s3.Region,
 			SignatureVersion: osspec.S3SignatureVersion(sigver),
 		},
@@ -59,8 +55,6 @@ func ConvertFromS3External(ext *osspec.S3) *S3Protocol {
 		vers = osspec.S3SignatureVersion_name[0]
 	}
 	return &S3Protocol{
-		BucketName: ext.BucketName,
-		Endpoint: ext.Endpoint,
 		Region: ext.Region,
 		SignatureVersion: S3SignatureVersion(vers),
 	}

--- a/apis/objectstorage.k8s.io/v1alpha1/types.go
+++ b/apis/objectstorage.k8s.io/v1alpha1/types.go
@@ -77,6 +77,10 @@ type BucketSpec struct {
 
 	// +kubebuilder:default:=retain
 	DeletionPolicy DeletionPolicy `json:"deletionPolicy"`
+
+	// BucketID is used for brownfield creation of buckets
+	// +optional
+	BucketID string `json:"bucketID,omitempty"`
 }
 
 type BucketStatus struct {
@@ -86,6 +90,8 @@ type BucketStatus struct {
 	// +optional
 	BucketAvailable bool `json:"bucketAvailable,omitempty"`
 
+	// BucketID is either filled in based on the brown name of the
+	// bucket, or it is dynamic filled based on the newly provisioned bucket
 	// +optional
 	BucketID string `json:"bucketID,omitempty"`
 }

--- a/crds/objectstorage.k8s.io_bucketclasses.yaml
+++ b/crds/objectstorage.k8s.io_bucketclasses.yaml
@@ -47,15 +47,11 @@ spec:
             properties:
               azureBlob:
                 properties:
-                  containerName:
-                    type: string
                   storageAccount:
                     type: string
                 type: object
               gcs:
                 properties:
-                  bucketName:
-                    type: string
                   privateKeyName:
                     type: string
                   projectID:
@@ -65,10 +61,6 @@ spec:
                 type: object
               s3:
                 properties:
-                  bucketName:
-                    type: string
-                  endpoint:
-                    type: string
                   region:
                     type: string
                   signatureVersion:

--- a/crds/objectstorage.k8s.io_buckets.yaml
+++ b/crds/objectstorage.k8s.io_buckets.yaml
@@ -37,6 +37,9 @@ spec:
                 x-kubernetes-list-type: atomic
               bucketClassName:
                 type: string
+              bucketID:
+                description: BucketID is used for brownfield creation of buckets
+                type: string
               bucketRequest:
                 description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
                 properties:
@@ -73,15 +76,11 @@ spec:
                 properties:
                   azureBlob:
                     properties:
-                      containerName:
-                        type: string
                       storageAccount:
                         type: string
                     type: object
                   gcs:
                     properties:
-                      bucketName:
-                        type: string
                       privateKeyName:
                         type: string
                       projectID:
@@ -91,10 +90,6 @@ spec:
                     type: object
                   s3:
                     properties:
-                      bucketName:
-                        type: string
-                      endpoint:
-                        type: string
                       region:
                         type: string
                       signatureVersion:
@@ -115,6 +110,7 @@ spec:
               bucketAvailable:
                 type: boolean
               bucketID:
+                description: BucketID is either filled in based on the brown name of the bucket, or it is dynamic filled based on the newly provisioned bucket
                 type: string
               message:
                 type: string

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -7,7 +7,7 @@ commonAnnotations:
   cosi.storage.k8s.io/license: "Apache V2"
   cosi.storage.k8s.io/support: "https://github.com/kubernetes-sigs/container-object-storage-api"
   controller-gen.kubebuilder.io/version: (devel)
-  api-approved.kubernetes.io: https://sigs.k8s.io/container-object-storage-interface-api/pull/2
+  api-approved.kubernetes.io: unapproved
 
 
 resources:


### PR DESCRIPTION
Fixes: #38
Fixes: #36 

This PR aims to remove the bucketName fields in the protocol in favor of the bucketID field in the `Bucket.spec`. We also remove the API-approved annotation. 
