### PR TITLE
Fix recording events

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -151,6 +151,7 @@ func NewObjectStorageControllerWithClientset(identity string, leaderLockName str
 	}
 
 	rb := record.NewBroadcaster()
+	rb.StartRecordingToSink(&corev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 
 	extendedScheme := scheme.Scheme
 	if err := v1alpha1.AddToScheme(extendedScheme); err != nil {


### PR DESCRIPTION
There is an issue with writing events in different namespaces: https://github.com/kubernetes-sigs/container-object-storage-interface-provisioner-sidecar/issues/140

This happens because events are created with a specified namespace, and the EventRecorder also has a namespace option set.

This PR removes the namespace option from the EventRecorder so events can be created in namespace they have specifyed.

Similar change can be found in this project
https://github.com/tsuru/remesher/commit/a8ccfa05b86a6d15b48546092c93f507f3121ad1#diff-243ebed2765f75e6a54f57167212fefb08c3b2a85967ad2acbc0eb78919019c1