### PR TITLE
monorepo: move event reason defs to api

### DIFF
--- a/client/apis/objectstorage/v1alpha1/events.go
+++ b/client/apis/objectstorage/v1alpha1/events.go
@@ -1,4 +1,4 @@
-package events
+package v1alpha1
 
 // COSI relevant event reasons
 const (


### PR DESCRIPTION
As a small part of moving to monorepo with separate controller and sidecar, they will need to share some code between them. For any code that reasonably applies as an API, let's plan for the API to be the location for that code. Start with event reason definitions.