### PR TITLE
add kubebuilder suggested e2e and lint targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 release-tools
 .idea
 travis.yml
-
+.cache

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,47 @@
+run:
+  timeout: 5m
+  allow-parallel-runners: true
+
+issues:
+  # don't skip warning about doc comments
+  # don't exclude the default set of lint
+  exclude-use-default: false
+  # restore some of the defaults
+  # (fill in the rest as needed)
+  exclude-rules:
+    - path: "apis/*"
+      linters:
+        - lll
+    - path: "internal/*"
+      linters:
+        - dupl
+        - lll
+linters:
+  disable-all: true
+  enable:
+    - copyloopvar
+    - dupl
+    - errcheck
+    - ginkgolinter
+    - goconst
+    - gocyclo
+    - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - prealloc
+    - revive
+    - staticcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+
+linters-settings:
+  revive:
+    rules:
+      - name: comment-spacings


### PR DESCRIPTION
Add the test-e2e, lint, and lint-fix targets that are suggested by kubebuilder, with adjustments to work for COSI monorepo.